### PR TITLE
macos/Runner.xcworkspace を追加する

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,6 @@ migrate_working_dir/
 .dart_tool/
 .packages
 build/
-*.xcworkspace
+*.xcworkspace/xcuserdata
 ios/_setup
 macos/_setup

--- a/example/macos/Runner.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/example/macos/Runner.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/example/macos/Runner.xcworkspace/contents.xcworkspacedata
+++ b/example/macos/Runner.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "group:Runner.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/example/macos/Runner.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/example/macos/Runner.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>


### PR DESCRIPTION
`.gitignore` で除外していた `example/macos/Runner.xcworkspace` を追加します。合わせて `.gitignore` では `*.xcworkspace` のうちユーザー固有のデータのみを除外するようにします。

この変更は、次の macOS のビルドエラーに対する修正です。リポジトリのクローン後に macOS のビルドをすると `No macOS desktop project configured.` のエラーが出ます。以下:

```
$ flutter build macos          
Running "flutter pub get" in example...                            243ms

💪 Building with sound null safety 💪

No macOS desktop project configured. See
https://docs.flutter.dev/desktop#add-desktop-support-to-an-existing-flutter-app to
learn about adding macOS support to a project.
```

このエラーは `macos/Runner.xcworkspace` が存在しない場合に発生します。 Flutter は macOS のビルド開始時に `Runner.xcworkspace` の存在をチェックするので、 `Runner.xcworkspace`  を Git の管理対象に含めていない本リポジトリでは (`pod install` を先に実行しない限り) エラーになります。

`macos/Runner.xcworkspace` は Flutter プロジェクト作成時に生成されるファイルですが、 `.gitignore` で `*.xcworkspace` を除外する設定にしていて追加しなかったのが原因です。

なお、 iOS では `Runner.xcworkspace` がなくても同様のエラーは発生しません。どうも Flutter は macOS のビルドでのみチェックしているようです。