### PR TITLE
公開する API を整理する

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -18,7 +18,6 @@ class MyApp extends StatefulWidget {
 
 class _MyAppState extends State<MyApp> {
   SoraClient? _soraClient;
-  final _soraFlutterSdkPlugin = SoraFlutterSdk();
 
   @override
   void initState() {
@@ -34,16 +33,17 @@ class _MyAppState extends State<MyApp> {
       return;
     }
 
-    final config = SoraClientConfig()
-      ..signalingUrls =
-          Environment.urlCandidates.map((e) => e.toString()).toList()
-      ..channelId = Environment.channelId
-      ..role = 'sendrecv';
-    final soraClient = await _soraFlutterSdkPlugin.createSoraClient(config)
-      ..onAddTrack = (String connectionId, int textureId) {
+    final config = SoraClientConfig(
+      signalingUrls:
+          Environment.urlCandidates.map((e) => e.toString()).toList(),
+      channelId: Environment.channelId,
+      role: SoraRole.sendrecv,
+    );
+    final soraClient = await SoraClient.create(config)
+      ..onAddTrack = (SoraVideoTrack track) {
         setState(() {/* soraClient.tracks の数が変動したので描画し直す */});
       }
-      ..onRemoveTrack = (String connectionId, int textureId) {
+      ..onRemoveTrack = (SoraVideoTrack track) {
         setState(() {/* soraClient.tracks の数が変動したので描画し直す */});
       };
     await soraClient.connect();
@@ -62,16 +62,19 @@ class _MyAppState extends State<MyApp> {
         ),
         body: Center(
           child: GridView.count(
-              crossAxisCount: 2,
-              children: _soraClient == null
-                  ? []
-                  : _soraClient!.tracks
-                      .map((e) => SizedBox(
-                            width: 320,
-                            height: 240,
-                            child: Texture(textureId: e.textureId),
-                          ))
-                      .toList()),
+            crossAxisCount: 2,
+            children: _soraClient == null
+                ? []
+                : _soraClient!.tracks
+                    .map(
+                      (track) => SoraRenderer(
+                        width: 320,
+                        height: 240,
+                        track: track,
+                      ),
+                    )
+                    .toList(),
+          ),
         ),
       ),
     );

--- a/lib/sora_flutter_sdk.dart
+++ b/lib/sora_flutter_sdk.dart
@@ -1,3 +1,4 @@
 export 'src/client.dart'
     show SoraClient, SoraClientConfig, SoraRole, SoraVideoCodecType;
 export 'src/video_track.dart' show SoraVideoTrack;
+export 'src/renderer.dart' show SoraRenderer;

--- a/lib/sora_flutter_sdk.dart
+++ b/lib/sora_flutter_sdk.dart
@@ -1,3 +1,3 @@
-export 'src/sdk.dart' show SoraFlutterSdk;
-export 'src/client.dart' show SoraClient, SoraClientConfig;
+export 'src/client.dart'
+    show SoraClient, SoraClientConfig, SoraRole, SoraVideoCodecType;
 export 'src/video_track.dart' show SoraVideoTrack;

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -15,19 +15,19 @@ class SoraClientConfig {
 
 class SoraClient {
   int clientId = 0;
-  String eventChannel = "";
   Function? onAddTrack;
   Function? onRemoveTrack;
   List<SoraVideoTrack> tracks = List<SoraVideoTrack>.empty(growable: true);
 
+  String _eventChannel = "";
   final Future<void> Function(SoraClient) _connector;
   final Future<void> Function(SoraClient) _disposer;
   StreamSubscription<dynamic>? _eventSubscription;
 
   SoraClient(dynamic resp, this._connector, this._disposer) {
     clientId = resp['client_id'];
-    eventChannel = resp['event_channel'];
-    _eventSubscription = EventChannel(eventChannel)
+    _eventChannel = resp['event_channel'];
+    _eventSubscription = EventChannel(_eventChannel)
         .receiveBroadcastStream()
         .listen(_eventListener, onError: _errorListener);
   }

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -3,17 +3,62 @@ import 'dart:async';
 import 'package:flutter/services.dart';
 
 import 'video_track.dart';
+import 'sdk.dart';
+
+enum SoraRole {
+  sendonly,
+  recvonly,
+  sendrecv,
+}
+
+enum SoraVideoCodecType {
+  vp8,
+  vp9,
+  av1,
+  h264,
+  h265,
+}
+
+extension SoraRoleRawValue on SoraRole {
+  static final Map<SoraRole, String> _rawValues = {
+    SoraRole.sendonly: "sendonly",
+    SoraRole.recvonly: "recvonly",
+    SoraRole.sendrecv: "sendrecv",
+  };
+  String get rawValues => _rawValues[this]!;
+}
+
+extension SoraVideoCodecTypeRawValue on SoraVideoCodecType {
+  static final Map<SoraVideoCodecType, String> _rawValues = {
+    SoraVideoCodecType.vp8: "VP8",
+    SoraVideoCodecType.vp9: "VP9",
+    SoraVideoCodecType.av1: "AV1",
+    SoraVideoCodecType.h264: "H264",
+    SoraVideoCodecType.h265: "H265",
+  };
+  String get rawValues => _rawValues[this]!;
+}
 
 class SoraClientConfig {
+  SoraClientConfig({
+    required this.signalingUrls,
+    required this.channelId,
+    required this.role,
+  });
+
   List<String> signalingUrls = List<String>.empty(growable: true);
-  String channelId = "";
-  String role = "sendrecv";
+  String channelId;
+  SoraRole role;
   int deviceWidth = 640;
   int deviceHeight = 480;
-  String videoCodecType = "";
+  SoraVideoCodecType? videoCodecType;
 }
 
 class SoraClient {
+  static Future<SoraClient> create(SoraClientConfig config) async {
+    return await SoraFlutterSdk.createSoraClient(config);
+  }
+
   int clientId = 0;
   Function? onAddTrack;
   Function? onRemoveTrack;

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:flutter/services.dart';
+import 'package:collection/collection.dart';
 
 import 'video_track.dart';
 import 'sdk.dart';
@@ -60,8 +61,8 @@ class SoraClient {
   }
 
   int clientId = 0;
-  Function? onAddTrack;
-  Function? onRemoveTrack;
+  void Function(SoraVideoTrack)? onAddTrack;
+  void Function(SoraVideoTrack)? onRemoveTrack;
   List<SoraVideoTrack> tracks = List<SoraVideoTrack>.empty(growable: true);
 
   String _eventChannel = "";
@@ -83,17 +84,23 @@ class SoraClient {
       case 'AddTrack':
         String connectionId = map['connection_id'];
         int textureId = map['texture_id'];
-        tracks.add(SoraVideoTrack(connectionId, textureId));
+        final track = SoraVideoTrack(connectionId, textureId);
+        tracks.add(track);
         if (onAddTrack != null) {
-          onAddTrack!(connectionId, textureId);
+          onAddTrack!(track);
         }
         break;
       case 'RemoveTrack':
         String connectionId = map['connection_id'];
         int textureId = map['texture_id'];
-        tracks.removeWhere((element) => element.textureId == textureId);
-        if (onRemoveTrack != null) {
-          onRemoveTrack!(connectionId, textureId);
+        SoraVideoTrack? track = tracks.firstWhereOrNull((element) =>
+            element.connectionId == connectionId &&
+            element.textureId == textureId);
+        if (track != null) {
+          tracks.remove(track);
+          if (onRemoveTrack != null) {
+            onRemoveTrack!(track);
+          }
         }
         break;
     }

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -26,7 +26,7 @@ extension SoraRoleRawValue on SoraRole {
     SoraRole.recvonly: "recvonly",
     SoraRole.sendrecv: "sendrecv",
   };
-  String get rawValues => _rawValues[this]!;
+  String get rawValue => _rawValues[this]!;
 }
 
 extension SoraVideoCodecTypeRawValue on SoraVideoCodecType {
@@ -37,7 +37,7 @@ extension SoraVideoCodecTypeRawValue on SoraVideoCodecType {
     SoraVideoCodecType.h264: "H264",
     SoraVideoCodecType.h265: "H265",
   };
-  String get rawValues => _rawValues[this]!;
+  String get rawValue => _rawValues[this]!;
 }
 
 class SoraClientConfig {

--- a/lib/src/method_channel.dart
+++ b/lib/src/method_channel.dart
@@ -15,10 +15,10 @@ class MethodChannelSoraFlutterSdk extends SoraFlutterSdkPlatform {
     final req = {
       'signaling_urls': config.signalingUrls,
       'channel_id': config.channelId,
-      'role': config.role,
+      'role': config.role.rawValue,
       'device_width': config.deviceWidth,
       'device_height': config.deviceHeight,
-      'video_codec_type': config.videoCodecType,
+      'video_codec_type': config.videoCodecType?.rawValue ?? '',
     };
     final resp = await methodChannel.invokeMethod('createSoraClient', req);
     final client = SoraClient(resp, _connectSoraClient, _disposeSoraClient);

--- a/lib/src/renderer.dart
+++ b/lib/src/renderer.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/widgets.dart';
+import 'video_track.dart';
+
+class SoraRenderer extends StatelessWidget {
+  const SoraRenderer({
+    super.key,
+    required this.width,
+    required this.height,
+    required this.track,
+  });
+
+  final int width;
+  final int height;
+  final SoraVideoTrack track;
+
+  @override
+  Widget build(BuildContext context) => SizedBox(
+        width: width.toDouble(),
+        height: height.toDouble(),
+        child: Texture(textureId: track.textureId),
+      );
+}

--- a/lib/src/sdk.dart
+++ b/lib/src/sdk.dart
@@ -3,7 +3,7 @@ import 'platform_interface.dart';
 import 'client.dart';
 
 class SoraFlutterSdk {
-  Future<SoraClient> createSoraClient(SoraClientConfig config) {
+  static Future<SoraClient> createSoraClient(SoraClientConfig config) {
     return SoraFlutterSdkPlatform.instance.createSoraClient(config);
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,6 +8,7 @@ environment:
   flutter: ">=2.5.0"
 
 dependencies:
+  collection: ^1.16.0
   flutter:
     sdk: flutter
   plugin_platform_interface: ^2.0.2


### PR DESCRIPTION
ユーザーに公開する API (Dart) を整理しました。現在の実装では特に制限していないので、ほとんどの API がユーザーから使える状態になっています。そのため、内部でのみ使う API を隠蔽しました。加えて、型検査のメリットを利用しやすいようにいくつかの既存の型を変更しました。

機能に関して破壊的変更はありません。

## 変更内容

- `SoraClientConfig` の変更
  - `role` 用の列挙型 `SoraRole` を追加する
  - `videoCodecType` 用の列挙型 `SoraVideoCodecType` を追加する
  - `videoCodecType` をオプショナル型に変更する
  - コンストラクタに、接続に必須のプロパティを引数に追加する
- `SoraClient` の変更
  - コンストラクタ代わりの `create()` を追加する。現在の実装ではユーザーは `SoraFlutterSdk.createSoraClient()` を使う必要があるが、 `SoraFlutterSdk` は他に使っていないので隠蔽して `SoraClient` に移す
  - `onAddTrack`, `onRemoveTrack` が受け取る引数をテクスチャ ID から `SoraVideoTrack` に変更する
  - `eventChannel` を隠蔽する
- 描画用のウィジェット `SoreRenderer` を追加する。現在の実装は低レベルなテクスチャウィジェットを使っているのでラッパーを用意して隠蔽する
- 以下の API のみをユーザーに公開し、他の API を隠蔽する
  - `SoraClient`, `SoraClientConfig`, `SoraRole`, `SoraVideoCodecType`, `SoraVideoTrack`, `SoraRenderer`
- 依存するパッケージに [collection](https://pub.dev/packages/collection) を追加する。コレクションの操作に便利なので、今回変更するコードで利用している
- 以上の変更に合わせて `example` 以下のコードを修正する