### PR TITLE
Feature/slim build

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,4 +1,6 @@
 include: package:flutter_lints/flutter.yaml
 
-# Additional information about this file can be found at
-# https://dart.dev/guides/language/analysis-options
+analyzer:
+  exclude:
+    - build/**
+    - example/**

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -4,3 +4,8 @@ analyzer:
   exclude:
     - build/**
     - example/**
+    - src/**
+    - ios/_setup/**
+    - macos/_setup/**
+    - android/_install/**
+    - linux/_install/**

--- a/example/analysis_options.yaml
+++ b/example/analysis_options.yaml
@@ -1,6 +1,10 @@
 # https://pub.dev/packages/pedantic_mono
 include: package:pedantic_mono/analysis_options.yaml
 
+analyzer:
+  exclude:
+    - build/**
+    
 linter:
   rules:
     - await_only_futures


### PR DESCRIPTION
Dart プラグインの解析対象から次のファイルを除外します。 VSCode や Android Studio の動作が少し軽くなります。

- C++ / ObjC のソースファイル
- Sora C++ SDK のビルドでダウンロードしたファイル (libwebrtc, Boost, Sora C++ SDK)
- example のビルド結果 (`example/build`)