### PR TITLE
build_runner の対象ファイルを明示的に指定する

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1,0 +1,4 @@
+targets:
+  $default:
+    sources:
+      - lib/src/*.dart


### PR DESCRIPTION
build_runner の設定ファイル `build.yaml` を用意し、対象となるファイルを指定します。現在は json_serializable でのみ build_runner を利用しているので、 `lib/src` 以下のソースコードのみを対象にします。

対象ファイルを指定することで、 build_runner の実行が短時間で済むようになります。対象ファイルが無指定だと `example` 以下のファイル (シンボリックリンク含む) も検索に含まれるので build_runner の実行に時間がかかります。

## 実行方法

以下のどちらかのコマンドで実行できます。

```
flutter pub run build_runner build
```

```
dart run build_runner build
```

## 備考

build_runner の実行時に以下の警告が出ますが、無視して問題ありません。

```
[WARNING] The package `sora_flutter_sdk` does not include some required sources in any of its targets (see their build.yaml file).
The missing sources are:
  - $package$
  - lib/$lib$
```