### PR TITLE
SoraAudioCodecType の公開、シグナリングオプションの修正

### DIFF
--- a/lib/sora_flutter_sdk.dart
+++ b/lib/sora_flutter_sdk.dart
@@ -1,4 +1,4 @@
 export 'src/client.dart'
-    show SoraClient, SoraClientConfig, SoraRole, SoraVideoCodecType;
+    show SoraClient, SoraClientConfig, SoraRole, SoraVideoCodecType, SoraAudioCodecType;
 export 'src/video_track.dart' show SoraVideoTrack;
 export 'src/renderer.dart' show SoraRenderer;

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -78,6 +78,7 @@ class SoraClientConfig {
   SoraVideoCodecType? videoCodecType;
   SoraAudioCodecType? audioCodecType;
   int? videoBitRate;
+  int? audioBitRate;
   int? audioOpusParamsClockRate;
   Map<String, dynamic>? metadata;
   Map<String, dynamic>? signalingNotifyMetadata;

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -79,7 +79,6 @@ class SoraClientConfig {
   SoraAudioCodecType? audioCodecType;
   int? videoBitRate;
   int? audioBitRate;
-  int? audioOpusParamsClockRate;
   Map<String, dynamic>? metadata;
   Map<String, dynamic>? signalingNotifyMetadata;
   SoraRole role;

--- a/lib/src/client.g.dart
+++ b/lib/src/client.g.dart
@@ -53,6 +53,7 @@ SoraClientConfig _$SoraClientConfigFromJson(Map<String, dynamic> json) =>
       ..audioCodecType = $enumDecodeNullable(
           _$SoraAudioCodecTypeEnumMap, json['audioCodecType'])
       ..videoBitRate = json['videoBitRate'] as int?
+      ..audioBitRate = json['audioBitRate'] as int?
       ..audioOpusParamsClockRate = json['audioOpusParamsClockRate'] as int?
       ..metadata = json['metadata'] as Map<String, dynamic>?
       ..signalingNotifyMetadata =
@@ -86,7 +87,8 @@ SoraClientConfig _$SoraClientConfigFromJson(Map<String, dynamic> json) =>
       ..useHardwareEncoder = json['useHardwareEncoder'] as bool?
       ..videoDeviceName = json['videoDeviceName'] as String?
       ..videoDeviceWidth = json['videoDeviceWidth'] as int?
-      ..videoDeviceHeight = json['videoDeviceHeight'] as int?;
+      ..videoDeviceHeight = json['videoDeviceHeight'] as int?
+      ..videoDeviceFps = json['videoDeviceFps'] as int?;
 
 Map<String, dynamic> _$SoraClientConfigToJson(SoraClientConfig instance) =>
     <String, dynamic>{
@@ -101,6 +103,7 @@ Map<String, dynamic> _$SoraClientConfigToJson(SoraClientConfig instance) =>
       'videoCodecType': _$SoraVideoCodecTypeEnumMap[instance.videoCodecType],
       'audioCodecType': _$SoraAudioCodecTypeEnumMap[instance.audioCodecType],
       'videoBitRate': instance.videoBitRate,
+      'audioBitRate': instance.audioBitRate,
       'audioOpusParamsClockRate': instance.audioOpusParamsClockRate,
       'metadata': instance.metadata,
       'signalingNotifyMetadata': instance.signalingNotifyMetadata,
@@ -132,6 +135,7 @@ Map<String, dynamic> _$SoraClientConfigToJson(SoraClientConfig instance) =>
       'videoDeviceName': instance.videoDeviceName,
       'videoDeviceWidth': instance.videoDeviceWidth,
       'videoDeviceHeight': instance.videoDeviceHeight,
+      'videoDeviceFps': instance.videoDeviceFps,
     };
 
 const _$SoraVideoCodecTypeEnumMap = {

--- a/lib/src/client.g.dart
+++ b/lib/src/client.g.dart
@@ -54,7 +54,6 @@ SoraClientConfig _$SoraClientConfigFromJson(Map<String, dynamic> json) =>
           _$SoraAudioCodecTypeEnumMap, json['audioCodecType'])
       ..videoBitRate = json['videoBitRate'] as int?
       ..audioBitRate = json['audioBitRate'] as int?
-      ..audioOpusParamsClockRate = json['audioOpusParamsClockRate'] as int?
       ..metadata = json['metadata'] as Map<String, dynamic>?
       ..signalingNotifyMetadata =
           json['signalingNotifyMetadata'] as Map<String, dynamic>?
@@ -104,7 +103,6 @@ Map<String, dynamic> _$SoraClientConfigToJson(SoraClientConfig instance) =>
       'audioCodecType': _$SoraAudioCodecTypeEnumMap[instance.audioCodecType],
       'videoBitRate': instance.videoBitRate,
       'audioBitRate': instance.audioBitRate,
-      'audioOpusParamsClockRate': instance.audioOpusParamsClockRate,
       'metadata': instance.metadata,
       'signalingNotifyMetadata': instance.signalingNotifyMetadata,
       'role': _$SoraRoleEnumMap[instance.role]!,

--- a/src/config_reader.h
+++ b/src/config_reader.h
@@ -148,6 +148,7 @@ sora::SoraSignalingConfig JsonToSignalingConfig(const std::string& json) {
   F(SetString, "videoCodecType", &c.video_codec_type);
   F(SetString, "audioCodecType", &c.audio_codec_type);
   F(SetInteger, "videoBitRate", &c.video_bit_rate);
+  F(SetInteger, "audioBitRate", &c.audio_bit_rate);
   F(SetInteger, "audioOpusParamsClockRate", &c.audio_opus_params_clock_rate);
   F(SetJson, "metadata", &c.metadata);
   F(SetJson, "signalingNotifyMetadata", &c.signaling_notify_metadata);

--- a/src/config_reader.h
+++ b/src/config_reader.h
@@ -149,7 +149,6 @@ sora::SoraSignalingConfig JsonToSignalingConfig(const std::string& json) {
   F(SetString, "audioCodecType", &c.audio_codec_type);
   F(SetInteger, "videoBitRate", &c.video_bit_rate);
   F(SetInteger, "audioBitRate", &c.audio_bit_rate);
-  F(SetInteger, "audioOpusParamsClockRate", &c.audio_opus_params_clock_rate);
   F(SetJson, "metadata", &c.metadata);
   F(SetJson, "signalingNotifyMetadata", &c.signaling_notify_metadata);
   F(SetString, "role", &c.role);


### PR DESCRIPTION
以下について修正をしています。

1. lib/sora_flutter_sdk.dart で `SoraAudioCodecType` を公開
2. シグナリングオプションに `audioBitRate` を追加
3. シグナリングオプションから `audioOpusParamsClockRate` を削除
4. lib/src/client.g.dart の再作成