### PR TITLE
SoraDataChannel  を参照可能にする

### DIFF
--- a/lib/sora_flutter_sdk.dart
+++ b/lib/sora_flutter_sdk.dart
@@ -1,4 +1,4 @@
 export 'src/client.dart'
-    show SoraClient, SoraClientConfig, SoraRole, SoraVideoCodecType, SoraAudioCodecType;
+    show SoraClient, SoraClientConfig, SoraRole, SoraVideoCodecType, SoraAudioCodecType, SoraDataChannel;
 export 'src/video_track.dart' show SoraVideoTrack;
 export 'src/renderer.dart' show SoraRenderer;


### PR DESCRIPTION
SoraDataChannel が外部から参照できなくなっていたため追加します。