### PR TITLE
metadata, signalingNotifyMetadata の型を dynamic に変更

### DIFF
--- a/example/lib/environment.example.dart
+++ b/example/lib/environment.example.dart
@@ -11,5 +11,5 @@ class Environment {
 
   static const String channelId = 'sora';
 
-  static const Map<String, dynamic>? signalingMetadata = null;
+  static const dynamic? signalingMetadata = null;
 }

--- a/example/lib/environment.example.dart
+++ b/example/lib/environment.example.dart
@@ -11,5 +11,5 @@ class Environment {
 
   static const String channelId = 'sora';
 
-  static const dynamic? signalingMetadata = null;
+  static const dynamic signalingMetadata = null;
 }

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -96,8 +96,8 @@ class SoraClientConfig {
   SoraAudioCodecType? audioCodecType;
   int? videoBitRate;
   int? audioBitRate;
-  Map<String, dynamic>? metadata;
-  Map<String, dynamic>? signalingNotifyMetadata;
+  dynamic metadata;
+  dynamic signalingNotifyMetadata;
   /// ロール
   SoraRole role;
   bool? multistream;

--- a/lib/src/client.g.dart
+++ b/lib/src/client.g.dart
@@ -54,9 +54,8 @@ SoraClientConfig _$SoraClientConfigFromJson(Map<String, dynamic> json) =>
           _$SoraAudioCodecTypeEnumMap, json['audioCodecType'])
       ..videoBitRate = json['videoBitRate'] as int?
       ..audioBitRate = json['audioBitRate'] as int?
-      ..metadata = json['metadata'] as Map<String, dynamic>?
-      ..signalingNotifyMetadata =
-          json['signalingNotifyMetadata'] as Map<String, dynamic>?
+      ..metadata = json['metadata']
+      ..signalingNotifyMetadata = json['signalingNotifyMetadata']
       ..multistream = json['multistream'] as bool?
       ..spotlight = json['spotlight'] as bool?
       ..spotlightNumber = json['spotlightNumber'] as int?


### PR DESCRIPTION
以下の確認を実施

- metadata に `"abc"` を設定
- signalingNotifyMetadata に` {"sora" : "tobi"}` を設定
- dataChannels が送信できること (影響を与えていないこと) 