### PR TITLE
macOS と iOS の SDK インストールフォルダを変更

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,5 +29,5 @@ migrate_working_dir/
 .packages
 build/
 *.xcworkspace/xcuserdata
-ios/_setup
-macos/_setup
+ios/_install
+macos/_install

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -5,7 +5,7 @@ analyzer:
     - build/**
     - example/**
     - src/**
-    - ios/_setup/**
-    - macos/_setup/**
+    - ios/_install/**
+    - macos/_install/**
     - android/_install/**
     - linux/_install/**

--- a/ios/sora_flutter_sdk.podspec
+++ b/ios/sora_flutter_sdk.podspec
@@ -1,4 +1,4 @@
-sdk_dir = "_setup"
+sdk_dir = "_install"
 
 Pod::Spec.new do |s|
   s.name = 'sora_flutter_sdk'

--- a/macos/sora_flutter_sdk.podspec
+++ b/macos/sora_flutter_sdk.podspec
@@ -3,7 +3,7 @@
 # Run `pod lib lint sora_flutter_sdk.podspec` to validate before publishing.
 #
 
-sdk_dir = "_setup"
+sdk_dir = "_install"
 
 Pod::Spec.new do |s|
   s.name = "sora_flutter_sdk"

--- a/scripts/apple/setup.sh
+++ b/scripts/apple/setup.sh
@@ -17,7 +17,7 @@ SDK_URL=https://github.com/shiguredo/sora-cpp-sdk/releases/download/$SDK_VERSION
 BOOST_URL=https://github.com/shiguredo/sora-cpp-sdk/releases/download/$SDK_VERSION/$BOOST_FILE
 WEBRTC_URL=https://github.com/shiguredo-webrtc-build/webrtc-build/releases/download/$WEBRTC_VERSION/$WEBRTC_FILE
 
-SETUP_DIR=_setup
+SETUP_DIR=_install
 
 
 cd ../../$(dirname $0)/$OS


### PR DESCRIPTION
他のプラットフォームでは SDK の格納場所を `_install` にしているため、 macOS と iOS の場所も同じ名前に合わせるように修正しました。