### PR TITLE
SoraClientConfig.signalingUrls の型を変更する

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -121,8 +121,7 @@ class _MyAppState extends State<MyApp> {
     }
 
     final config = SoraClientConfig(
-      signalingUrls:
-      Environment.urlCandidates.map((e) => e.toString()).toList(),
+      signalingUrls: Environment.urlCandidates,
       channelId: Environment.channelId,
       role: SoraRole.sendrecv,
     );

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -80,7 +80,8 @@ class SoraClientConfig {
   // SoraSignalingConfig の設定
 
   /// シグナリング URL のリスト
-  List<String> signalingUrls;
+  List<Uri> signalingUrls;
+
   /// チャネル ID
   String channelId;
   String? clientId;

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -9,7 +9,7 @@ import 'video_track.dart';
 import 'sdk.dart';
 
 // 次のコマンドで生成できる (build_runner のインストールが必要)
-// dart run build_runner build
+// flutter pub run build_runner build
 part 'client.g.dart';
 
 /// 接続時のロールを表します。

--- a/lib/src/client.g.dart
+++ b/lib/src/client.g.dart
@@ -37,7 +37,7 @@ const _$SoraRoleEnumMap = {
 SoraClientConfig _$SoraClientConfigFromJson(Map<String, dynamic> json) =>
     SoraClientConfig(
       signalingUrls: (json['signalingUrls'] as List<dynamic>)
-          .map((e) => e as String)
+          .map((e) => Uri.parse(e as String))
           .toList(),
       channelId: json['channelId'] as String,
       role: $enumDecode(_$SoraRoleEnumMap, json['role']),
@@ -91,7 +91,7 @@ SoraClientConfig _$SoraClientConfigFromJson(Map<String, dynamic> json) =>
 
 Map<String, dynamic> _$SoraClientConfigToJson(SoraClientConfig instance) =>
     <String, dynamic>{
-      'signalingUrls': instance.signalingUrls,
+      'signalingUrls': instance.signalingUrls.map((e) => e.toString()).toList(),
       'channelId': instance.channelId,
       'clientId': instance.clientId,
       'bundleId': instance.bundleId,


### PR DESCRIPTION
`SoraClientConfig.signalingUrls` の型を `List<String>` から `List<Uri>` に変更します。 Dart では URL を表す `Uri` クラスがあるので、 URL を単なる文字列ではなく `Uri` で扱うようにします。 `client.g.dart` も再生成しています。

それと、 `client.g.dart` の生成に使うコマンドについてコメントを変更しました。 `flutter` コマンドで生成できるので、 Flutter アプリであればそちらを使うほうがいいです。