### PR TITLE
[CI] actions/setup-java を v3 にあげる

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -43,7 +43,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-java@v2
+      - uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
           java-version: '11'


### PR DESCRIPTION
GitHub Actions でワーニングが出ていたことによる対応です。

以下でワーニングが出なくなったことを確認しています。
https://github.com/shiguredo/sora-flutter-sdk/actions/runs/3416700397