### PR TITLE
DataChannel のメッセージをバイナリで受け取るようにする

### DIFF
--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -161,7 +161,7 @@ class SoraClient {
   void Function(String, String)? onDisconnect;
   void Function(String)? onNotify;
   void Function(String)? onPush;
-  void Function(String, String)? onMessage;
+  void Function(String label, Uint8List data)? onMessage;
   /// 映像トラックが追加されたときに呼ばれるコールバック
   void Function(SoraVideoTrack)? onAddTrack;
   /// 映像トラックが本オブジェクトから除去されたときに呼ばれるコールバック
@@ -219,7 +219,8 @@ class SoraClient {
         break;
       case 'Message':
         String label = js['label'];
-        String data = js['data'];
+        List<int> rawData = js['data'];
+        final data = Uint8List.fromList(rawData);
         if (onMessage != null) {
           onMessage!(label, data);
         }

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -220,8 +220,7 @@ class SoraClient {
       case 'Message':
         String label = js['label'];
         List<dynamic> rawData = js['data'];
-        final data = Uint8List.fromList(
-            rawData.map((e) => int.parse(e.toString())).toList());
+        final data = Uint8List.fromList(rawData.cast<int>());
         if (onMessage != null) {
           onMessage!(label, data);
         }

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -219,8 +219,9 @@ class SoraClient {
         break;
       case 'Message':
         String label = js['label'];
-        List<int> rawData = js['data'];
-        final data = Uint8List.fromList(rawData);
+        List<dynamic> rawData = js['data'];
+        final data = Uint8List.fromList(
+            rawData.map((e) => int.parse(e.toString())).toList());
         if (onMessage != null) {
           onMessage!(label, data);
         }

--- a/src/sora_client.cpp
+++ b/src/sora_client.cpp
@@ -348,7 +348,11 @@ void SoraClient::OnMessage(std::string label, std::string data) {
   boost::json::object obj;
   obj["event"] = "Message";
   obj["label"] = label;
-  obj["data"] = data;
+  boost::json::array bytes;
+  for (int i = 0; i < data.length(); i++) {
+    bytes.push_back(data[i]);
+  }
+  obj["data"] = bytes;
   SendEvent(obj);
 }
 

--- a/src/sora_client.cpp
+++ b/src/sora_client.cpp
@@ -350,7 +350,7 @@ void SoraClient::OnMessage(std::string label, std::string data) {
   obj["label"] = label;
   boost::json::array bytes;
   for (int i = 0; i < data.length(); i++) {
-    bytes.push_back(data[i]);
+    bytes.push_back((uint8_t)data[i]);
   }
   obj["data"] = bytes;
   SendEvent(obj);


### PR DESCRIPTION
DataChannel メッセージ受信時に呼ばれるコールバックの引数のうち、受信したデータの型を String から Uint8List に変更しました。この変更により、バイナリデータを安全に受信できるようになります。文字列として扱う場合、バイナリデータの内容が Dart の文字列として不正な場合に変換に失敗する可能性があります。