### PR TITLE
sora_client に Sora Flutter SDK と Flutter のバージョンを含める

### DIFF
--- a/example/lib/environment.example.dart
+++ b/example/lib/environment.example.dart
@@ -5,6 +5,9 @@
 // ignore_for_file: unnecessary_nullable_for_final_variable_declarations
 
 class Environment {
+
+  static const String flutterVersion = '3.3.10';
+
   static final List<Uri> urlCandidates = [
     Uri.parse('wss://sora.example.com/signaling')
   ];

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -6,6 +6,8 @@ import 'package:sora_flutter_sdk/sora_flutter_sdk.dart';
 import 'environment.dart';
 
 void main() {
+  SoraClientConfig.flutterVersion = '3.3.9';
+
   runApp(const MyApp());
 }
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -6,7 +6,7 @@ import 'package:sora_flutter_sdk/sora_flutter_sdk.dart';
 import 'environment.dart';
 
 void main() {
-  SoraClientConfig.flutterVersion = '3.3.9';
+  SoraClientConfig.flutterVersion = Environment.flutterVersion;
 
   runApp(const MyApp());
 }

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -127,7 +127,9 @@ class SoraClientConfig {
     required this.signalingUrls,
     required this.channelId,
     required this.role,
-  });
+  }) {
+    soraClient = 'Sora Flutter SDK ${Version.sdkVersion}';
+  }
 
   /// シグナリング URL のリスト
   List<Uri> signalingUrls;
@@ -142,7 +144,7 @@ class SoraClientConfig {
   String? bundleId;
 
   /// クライアント名
-  String soraClient = "Sora Flutter SDK";
+  late String soraClient;
 
   /// 証明書の検証の可否。 true を指定すると検証を行いません。
   bool? insecure;

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -123,13 +123,24 @@ class SoraDataChannel {
 /// 接続設定です。
 @JsonSerializable()
 class SoraClientConfig {
+  /// アプリケーションが利用する Flutter のバージョンを指定します。
+  /// 指定したバージョンはシグナリングでクライアント情報に含まれます。
+  /// 必ず指定してください。
+  static String? flutterVersion;
+
   /// 本オブジェクトを生成します。
   SoraClientConfig({
     required this.signalingUrls,
     required this.channelId,
     required this.role,
   }) {
-    soraClient = 'Sora Flutter SDK ${Version.sdkVersion}';
+    if (flutterVersion == null) {
+      throw UnimplementedError(
+          'SoraClientConfig.flutterVersion must be specified');
+    }
+    soraClient = 'Sora Flutter SDK ${Version.sdkVersion} '
+        '(Flutter ${SoraClientConfig.flutterVersion!}, '
+        'Dart ${Platform.version})';
   }
 
   /// シグナリング URL のリスト

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:io';
 
 import 'package:flutter/services.dart';
 import 'package:collection/collection.dart';

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -7,6 +7,7 @@ import 'dart:convert';
 
 import 'video_track.dart';
 import 'sdk.dart';
+import 'version.dart';
 
 // 次のコマンドで生成できる (build_runner のインストールが必要)
 // flutter pub run build_runner build

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,0 +1,5 @@
+// ignore_for_file: avoid_classes_with_only_static_members
+
+class Version {
+  static String sdkVersion = "2022.1.0-canary.7";
+}


### PR DESCRIPTION
type: connect の sora_client に以下のバージョンを含めるようにします。

- Sora Flutter SDK のバージョン
- ユーザーが使用する Flutter のバージョン
- ユーザーが使用する Dart ランタイム のバージョン

出力例: `Sora Flutter SDK 2022.1.0-canary.7 (Flutter 3.3.9, Dart 2.18.2 (stable) (Tue Sep 27 13:24:11 2022 +0200) on "ios_arm64")`

上記のうち、 Dart を除く 2 つは手動で記述する必要があります。それぞれ記述者が異なります。

- Sora Flutter SDK のバージョン
  - SDK の開発者が記述します
  - `lib/lsrc/version.dart` の `Version.sdkVersion` に指定します
  - SDK のアップデート時に更新する必要があります
- ユーザーが使用する Flutter のバージョン
  - SDK を利用するアプリの作成者が記述します。 SDK の開発者が記述する必要はありません
  - `SoraClientConfig.flutterVersion` に指定します。指定しない場合は SoraClientConfig の生成時にエラーが発生します
  - ユーザーは Flutter をアップデートしたら更新する必要があります