### PR TITLE
SoraClient の解放時に MissingPluginException が発生する事象を修正する

### DIFF
--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -202,8 +202,8 @@ class SoraClient {
         if (onDisconnect != null) {
           onDisconnect!(errorCode, message);
         }
-        _destructor(this);
         _eventSubscription?.cancel();
+        _destructor(this);
         break;
       case 'Notify':
         String text = js['text'];


### PR DESCRIPTION
SoraClient の解放時、ネイティブプラグイン側で MissingPluginException が発生する事象を修正します。

原因は、 EventChannel を無効化する `_eventSubscription?.cancel()` の前に `_destructor` を実行すると先に EventChannel が解放されてしまうことです。そのため、 `_destructor` の実行を `_eventSubscription?.cancel()` のあとに変更します。