### PR TITLE
[Linux] 接続時にカメラデバイスを指定するとクラッシュする事象を修正する

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -14,7 +14,7 @@ void main() async {
   WidgetsFlutterBinding.ensureInitialized();
   final devices = await DeviceList.videoCapturers();
   for (final device in devices) {
-    print('device => ${device.device}, ${device.unique}');
+    print('device => $device');
   }
   final frontCamera = await DeviceList.frontCamera();
   final backCamera = await DeviceList.backCamera();
@@ -293,9 +293,9 @@ class DeviceListDropdownButton extends StatelessWidget {
           DropdownButton(
             value: connectDevice,
             items: capturers
-                .map((DeviceName name) => DropdownMenuItem(
-                      child: Text('${name.index}: ${name.device}'),
-                      value: name,
+                .map((DeviceName device) => DropdownMenuItem(
+                      child: Text('${device.name}'),
+                      value: device,
                     ))
                 .toList(),
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -38,7 +38,7 @@ class _MyAppState extends State<MyApp> {
   var _capturerNum = 0;
 
   // 接続時に使用するカメラ、または使用中のカメラ
-  String? _connectDevice;
+  DeviceName? _connectDevice;
   var _video = true;
   var _audio = true;
   var _audioCodec = SoraAudioCodecType.opus;
@@ -52,7 +52,7 @@ class _MyAppState extends State<MyApp> {
       final capturers = await DeviceList.videoCapturers();
       setState(() {
         _capturers = capturers;
-        _connectDevice = _capturers.firstOrNull?.device;
+        _connectDevice = _capturers.firstOrNull;
       });
     }();
   }
@@ -202,7 +202,7 @@ class _MyAppState extends State<MyApp> {
     });
   }
 
-  Future<void> _setCamera(String? name) async {
+  Future<void> _setCamera(DeviceName? name) async {
     if (name == null) {
       return;
     }
@@ -238,7 +238,7 @@ class _MyAppState extends State<MyApp> {
     if (next >= _capturers.length) {
       next = 0;
     }
-    final name = _capturers[next].device;
+    final name = _capturers[next];
     final result = await _doSwitchCamera(name);
     if (result) {
       setState(() {
@@ -247,8 +247,8 @@ class _MyAppState extends State<MyApp> {
     }
   }
 
-  Future<bool> _doSwitchCamera(String name) async {
-    print('switch => ${name}');
+  Future<bool> _doSwitchCamera(DeviceName name) async {
+    print('switch => $name');
 
     // カメラの切替中は切替ボタンを無効にしたいので、
     // switchVideoDevice を非同期で呼んでから画面を更新する。
@@ -281,9 +281,9 @@ class DeviceListDropdownButton extends StatelessWidget {
     required this.onChanged,
   });
 
-  final String? connectDevice;
+  final DeviceName? connectDevice;
   final List<DeviceName> capturers;
-  final void Function(String?) onChanged;
+  final void Function(DeviceName?) onChanged;
 
   @override
   Widget build(BuildContext context) => Row(
@@ -294,8 +294,8 @@ class DeviceListDropdownButton extends StatelessWidget {
             value: connectDevice,
             items: capturers
                 .map((DeviceName name) => DropdownMenuItem(
-                      child: Text(name.device),
-                      value: name.device,
+                      child: Text('${name.index}: ${name.device}'),
+                      value: name,
                     ))
                 .toList(),
 

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -6,6 +6,7 @@ import 'package:collection/collection.dart';
 import 'package:flutter/services.dart';
 import 'package:json_annotation/json_annotation.dart';
 
+import 'device_list.dart';
 import 'lyra.dart';
 import 'platform_interface.dart';
 import 'sdk.dart';
@@ -304,7 +305,16 @@ class SoraClientConfig {
   bool? useHardwareEncoder;
 
   /// 利用する映像デバイス名
-  String? videoDeviceName;
+  @JsonKey(fromJson: _videoDeviceNameFrom, toJson: _videoDeviceNameOf)
+  DeviceName? videoDeviceName;
+
+  static DeviceName? _videoDeviceNameFrom(dynamic value) {
+    throw UnsupportedError('SoraClientConfig.videoDeviceName from JSON');
+  }
+
+  static String? _videoDeviceNameOf(DeviceName? name) {
+    return name != null ? '${name.index}' : null;
+  }
 
   /// 映像デバイスの横幅
   int? videoDeviceWidth;
@@ -517,7 +527,7 @@ class SoraClient {
   /// 現在、本メソッドは iOS と Android にのみ対応しています。
   /// 他のプラットフォームでは何もせずに [false] を返します。
   Future<bool> switchVideoDevice({
-    required String name,
+    required DeviceName name,
     int? width,
     int? height,
     int? fps,
@@ -532,7 +542,7 @@ class SoraClient {
       _switchingVideoDevice = true;
       await SoraFlutterSdkPlatform.instance.switchVideoDevice(
         client: this,
-        name: name,
+        name: name.index.toString(),
         width: width,
         height: height,
         fps: fps,

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -313,7 +313,7 @@ class SoraClientConfig {
   }
 
   static String? _videoDeviceNameOf(DeviceName? name) {
-    return name?.unique;
+    return name?.id;
   }
 
   /// 映像デバイスの横幅
@@ -542,7 +542,7 @@ class SoraClient {
       _switchingVideoDevice = true;
       await SoraFlutterSdkPlatform.instance.switchVideoDevice(
         client: this,
-        name: name.index.toString(),
+        name: name.id,
         width: width,
         height: height,
         fps: fps,

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -313,7 +313,7 @@ class SoraClientConfig {
   }
 
   static String? _videoDeviceNameOf(DeviceName? name) {
-    return name != null ? '${name.index}' : null;
+    return name?.unique;
   }
 
   /// 映像デバイスの横幅

--- a/lib/src/client.g.dart
+++ b/lib/src/client.g.dart
@@ -124,7 +124,8 @@ SoraClientConfig _$SoraClientConfigFromJson(Map<String, dynamic> json) =>
           json['disableSignalingUrlRandomization'] as bool?
       ..useAudioDeivce = json['useAudioDeivce'] as bool?
       ..useHardwareEncoder = json['useHardwareEncoder'] as bool?
-      ..videoDeviceName = json['videoDeviceName'] as String?
+      ..videoDeviceName =
+          SoraClientConfig._videoDeviceNameFrom(json['videoDeviceName'])
       ..videoDeviceWidth = json['videoDeviceWidth'] as int?
       ..videoDeviceHeight = json['videoDeviceHeight'] as int?
       ..videoDeviceFps = json['videoDeviceFps'] as int?;
@@ -188,7 +189,8 @@ Map<String, dynamic> _$SoraClientConfigToJson(SoraClientConfig instance) {
       instance.disableSignalingUrlRandomization);
   writeNotNull('useAudioDeivce', instance.useAudioDeivce);
   writeNotNull('useHardwareEncoder', instance.useHardwareEncoder);
-  writeNotNull('videoDeviceName', instance.videoDeviceName);
+  writeNotNull('videoDeviceName',
+      SoraClientConfig._videoDeviceNameOf(instance.videoDeviceName));
   writeNotNull('videoDeviceWidth', instance.videoDeviceWidth);
   writeNotNull('videoDeviceHeight', instance.videoDeviceHeight);
   writeNotNull('videoDeviceFps', instance.videoDeviceFps);

--- a/lib/src/device_list.dart
+++ b/lib/src/device_list.dart
@@ -9,13 +9,30 @@ import 'package:sora_flutter_sdk/src/platform_interface.dart';
 /// デバイス名は [SoraClientConfig.videoDeviceName] や [SoraClient.switchVideoDevice] でカメラを指定するのに使います。
 /// [device], [unique] のどちらも使用できます。
 class DeviceName {
-  DeviceName({required this.device, required this.unique});
+  DeviceName({required this.index, required this.device, required this.unique});
+
+  final int index;
 
   /// デバイス名
   final String device;
 
   /// デバイスのユニーク名
   final String unique;
+
+  @override
+  String toString() {
+    return '<Device $index, $device, $unique>';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is DeviceName && unique == other.unique;
+  }
+
+  @override
+  int get hashCode {
+    return unique.hashCode;
+  }
 }
 
 /// 端末に搭載されているデバイスのリストを取得します。
@@ -65,9 +82,16 @@ class DeviceList {
   /// 端末に搭載されているカメラのリストを返します。
   static Future<List<DeviceName>> videoCapturers() async {
     final capturers = await SoraFlutterSdkPlatform.instance.videoCapturers();
+    var i = 0;
     return capturers.map((resp) {
       final Map<dynamic, dynamic> map = resp;
-      return DeviceName(device: map['device'], unique: map['unique']);
+      final device = DeviceName(
+        index: i,
+        device: map['device'],
+        unique: map['unique'],
+      );
+      i++;
+      return device;
     }).toList();
   }
 }

--- a/lib/src/device_list.dart
+++ b/lib/src/device_list.dart
@@ -1,55 +1,66 @@
 import 'dart:io';
 
 import 'package:collection/collection.dart';
+import 'package:flutter/foundation.dart';
 import 'package:sora_flutter_sdk/src/platform_interface.dart';
 
 /// 端末に搭載されているデバイスの名前です。
 /// デバイス名は [DeviceList.videoCapturers] などの API で取得できます。
 ///
 /// デバイス名は [SoraClientConfig.videoDeviceName] や [SoraClient.switchVideoDevice] でカメラを指定するのに使います。
-/// [device], [unique] のどちらも使用できます。
 class DeviceName {
-  DeviceName({required this.index, required this.device, required this.unique});
-
-  final int index;
+  @protected
+  DeviceName({
+    required String name,
+    required String id,
+  }) {
+    _name = name;
+    _id = id;
+  }
 
   /// デバイス名
-  final String device;
+  String get name => _name;
 
-  /// デバイスのユニーク名
-  final String unique;
+  late final String _name;
+
+  /// デバイス ID
+  String get id => _id;
+
+  late final String _id;
 
   @override
   String toString() {
-    return '<Device $index, $device, $unique>';
+    return '<Device "$_name", "$_id">';
   }
 
   @override
   bool operator ==(Object other) {
-    return other is DeviceName && unique == other.unique;
+    return other is DeviceName && _id == other._id;
   }
 
   @override
   int get hashCode {
-    return unique.hashCode;
+    return _id.hashCode;
   }
 }
 
 /// 端末に搭載されているデバイスのリストを取得します。
 class DeviceList {
+  static Future<DeviceName?> _findDeviceName(String name) async {
+    return (await videoCapturers()).firstWhereOrNull(
+      (DeviceName e) => e.name.contains(name),
+    );
+  }
+
   /// 前面カメラの名前を返します。
   ///
   /// 本メソッドは iOS と Android のみ対応しています。
-  static Future<String?> frontCamera() async {
+  static Future<DeviceName?> frontCamera() async {
     try {
       if (Platform.isIOS) {
-        return 'Front Camera';
+        return _findDeviceName('Front Camera');
       } else if (Platform.isAndroid) {
-        return (await videoCapturers())
-            .firstWhereOrNull(
-              (DeviceName e) => e.device.contains('@+frontfacing'),
-            )
-            ?.device;
+        return _findDeviceName('@+frontfacing');
       } else {
         return null;
       }
@@ -61,16 +72,12 @@ class DeviceList {
   /// 背面カメラの名前を返します。
   ///
   /// 本メソッドは iOS と Android のみ対応しています。
-  static Future<String?> backCamera() async {
+  static Future<DeviceName?> backCamera() async {
     try {
       if (Platform.isIOS) {
-        return 'Back Camera';
+        return _findDeviceName('Back Camera');
       } else if (Platform.isAndroid) {
-        return (await videoCapturers())
-            .firstWhereOrNull(
-              (DeviceName e) => e.device.contains('@+backfacing'),
-            )
-            ?.device;
+        return _findDeviceName('@+backfacing');
       } else {
         return null;
       }
@@ -82,16 +89,12 @@ class DeviceList {
   /// 端末に搭載されているカメラのリストを返します。
   static Future<List<DeviceName>> videoCapturers() async {
     final capturers = await SoraFlutterSdkPlatform.instance.videoCapturers();
-    var i = 0;
     return capturers.map((resp) {
       final Map<dynamic, dynamic> map = resp;
-      final device = DeviceName(
-        index: i,
-        device: map['device'],
-        unique: map['unique'],
+      return DeviceName(
+        name: map['device'],
+        id: map['unique'],
       );
-      i++;
-      return device;
     }).toList();
   }
 }

--- a/src/device_list.h
+++ b/src/device_list.h
@@ -10,6 +10,10 @@ class DeviceList {
  public:
   static bool EnumVideoCapturer(
       std::function<void(std::string, std::string)> f);
+ private:
+#if defined(__linux__)
+  static bool FindDevice(const char* deviceUniqueIdUTF8, const std::string& device);
+#endif
 };
 
 }  // namespace sora_flutter_sdk


### PR DESCRIPTION
Linux にて、 `SoraClientConfig.videoDeviceName` にカメラデバイス名を指定するとクラッシュする事象を修正します。

## 変更点

- (Linux のみ) 指定するデバイス名にデバイスファイル (`/dev/video0` など) を渡す
  - デバイスファイル検索の実装は Sora C++ SDK を参考にした (https://github.com/shiguredo/sora-cpp-sdk/blob/develop/src/v4l2/v4l2_video_capturer.cpp)